### PR TITLE
feat: add copy button to code blocks

### DIFF
--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -16,9 +16,11 @@ function extractText(node: ReactNode): string {
 export const CodeBlock = (props: React.ComponentProps<"pre">) => {
   const text = extractText(props.children);
   return (
-    <pre {...props} className="**:data-line:px-4 relative">
+    <div className="relative">
       <CopyButton text={text} />
-      {props.children}
-    </pre>
+      <pre {...props} className="**:data-line:px-4">
+        {props.children}
+      </pre>
+    </div>
   );
 };

--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -1,0 +1,24 @@
+import { ReactNode } from "react";
+import { CopyButton } from "./CopyButton";
+
+function extractText(node: ReactNode): string {
+  if (typeof node === "string") return node;
+  if (typeof node === "number") return String(node);
+  if (!node) return "";
+  if (Array.isArray(node)) return node.map(extractText).join("");
+  if (typeof node === "object" && "props" in node) {
+    const { props } = node as { props: { children?: ReactNode } };
+    return extractText(props.children);
+  }
+  return "";
+}
+
+export const CodeBlock = (props: React.ComponentProps<"pre">) => {
+  const text = extractText(props.children);
+  return (
+    <pre {...props} className="**:data-line:px-4 relative">
+      <CopyButton text={text} />
+      {props.children}
+    </pre>
+  );
+};

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { Copy, Check } from "react-feather";
+
+export const CopyButton = ({ text }: { text: string }) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleClick = useCallback(async () => {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [text]);
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-label="Copy code"
+      className="absolute top-2 right-2 cursor-pointer rounded-md p-1.5 text-neutral-400 transition-colors hover:bg-neutral-700 hover:text-neutral-200"
+    >
+      {copied ? <Check size={16} /> : <Copy size={16} />}
+    </button>
+  );
+};

--- a/src/components/EntryView.tsx
+++ b/src/components/EntryView.tsx
@@ -11,6 +11,7 @@ import { ShareButtons } from "./ShareButtons";
 import { ZoomWrapper } from "./ZoomWrapper";
 import { EntryImage } from "./EntryImage";
 import { AppLink } from "./AppLink";
+import { CodeBlock } from "./CodeBlock";
 interface Props {
   entry: Entry;
   shareButton?: boolean;
@@ -104,7 +105,7 @@ export const EntryView = async ({ entry, shareButton, path }: Props) => {
       h4: (props) => <Heading level={4} {...props} />,
       h5: (props) => <Heading level={5} {...props} />,
       h6: (props) => <Heading level={6} {...props} />,
-      pre: (props) => <pre {...props} className="**:data-line:px-4" />,
+      pre: (props) => <CodeBlock {...props} />,
     },
   });
   return (


### PR DESCRIPTION
## Summary
- ブログ記事のコードブロック（`<pre>`）にクリップボードコピーボタンを追加
- コピー成功時にチェックマークアイコンに切り替わり、2秒後に戻る
- 横スクロール時もボタンが右上に固定されるようラッパー `<div>` で配置

## Test plan
- [ ] `pnpm build` が成功すること
- [ ] dev server でコードブロックを含む記事を表示し、コピーボタンが右上に表示されること
- [ ] コピーボタンをクリックしてクリップボードにコードがコピーされること
- [ ] 横に長いコードブロックをスクロールしてもボタンが固定されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)