### PR TITLE
fix: improve Japanese text wrapping with proper CSS properties

### DIFF
--- a/src/app/styles/styles.css
+++ b/src/app/styles/styles.css
@@ -56,6 +56,9 @@ body {
   font-feature-settings: "palt" 1;
   text-rendering: geometricPrecision;
   text-autospace: normal;
+  overflow-wrap: anywhere;
+  word-break: normal;
+  line-break: strict;
 }
 
 pre[data-theme*="material-theme-lighter"],

--- a/src/components/EntryView.tsx
+++ b/src/components/EntryView.tsx
@@ -110,7 +110,7 @@ export const EntryView = async ({ entry, shareButton, path }: Props) => {
   return (
     <article
       className={cn(
-        "overflow-visible [word-break:auto-phrase]",
+        "overflow-visible",
         "prose-pre:bg-unset prose-pre:py-4 prose-pre:px-0 prose-pre:shadow-xs",
       )}
     >


### PR DESCRIPTION
## Summary
- `body` に `overflow-wrap: anywhere`、`word-break: normal`、`line-break: strict` を追加し、日本語の折り返しを改善
- `EntryView.tsx` の `<article>` から `[word-break:auto-phrase]` を削除
- ICS Media の記事 (https://ics.media/entry/240411/) で推奨されている CSS プロパティの組み合わせに準拠

## Test plan
- [x] `pnpm build` が成功すること
- [ ] dev server で日本語記事を表示し、折り返しが改善されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)