### PR TITLE
refactor: convert arrow functions to function declarations

### DIFF
--- a/src/app/entries/[slug]/page.tsx
+++ b/src/app/entries/[slug]/page.tsx
@@ -34,7 +34,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   };
 }
 
-const EntryPage = async (props: Props) => {
+async function EntryPage(props: Props) {
   const params = await props.params;
 
   const { slug } = params;
@@ -44,7 +44,7 @@ const EntryPage = async (props: Props) => {
   return (
     <EntryView entry={entry} path={`/entries/${entry.slug}`} shareButton />
   );
-};
+}
 
 export default EntryPage;
 

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -4,13 +4,13 @@ export const metadata: Metadata = {
   title: "404 - Page not found",
 };
 
-const NotFound = () => {
+function NotFound() {
   return (
     <div className="text-center">
       <h1 className="mt-10">404</h1>
       <p>Page not found.</p>
     </div>
   );
-};
+}
 
 export default NotFound;

--- a/src/components/AbsDate.tsx
+++ b/src/components/AbsDate.tsx
@@ -4,11 +4,11 @@ interface Props extends React.HTMLAttributes<HTMLTimeElement> {
   date: number;
 }
 
-export const AbsDate = ({ date, ...rest }: Props) => {
+export function AbsDate({ date, ...rest }: Props) {
   const [formatted, day] = yyyymmdd(date);
   return (
     <time dateTime={day.format()} {...rest}>
       {formatted}
     </time>
   );
-};
+}

--- a/src/components/AppFooter.tsx
+++ b/src/components/AppFooter.tsx
@@ -1,7 +1,7 @@
 import { GitHub, Twitter } from "react-feather";
 import { config } from "../../blog.config";
 
-export const AppFooter = () => {
+export function AppFooter() {
   return (
     <footer className="container my-16 flex flex-row items-center justify-start gap-x-4">
       <p className="my-0 text-sm">Created by {config.author}.</p>
@@ -35,4 +35,4 @@ export const AppFooter = () => {
       </div>
     </footer>
   );
-};
+}

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -7,11 +7,11 @@ import { cn } from "../lib/util";
 import { rubik } from "../app/fonts";
 import { AppLink } from "./AppLink";
 
-export const NavLink = ({
+export function NavLink({
   children,
   href,
   ...props
-}: AnchorHTMLAttributes<HTMLAnchorElement>) => {
+}: AnchorHTMLAttributes<HTMLAnchorElement>) {
   const path = usePathname();
   const isActive = path === href;
   if (isActive || !href) {
@@ -23,14 +23,14 @@ export const NavLink = ({
       </AppLink>
     );
   }
-};
+}
 
 const Title = config
   .title()
   .split("")
   .map((char, index) => <span key={index}>{char}</span>);
 
-export const AppHeader = () => {
+export function AppHeader() {
   const path = usePathname();
   const isIndex = path === "/";
   return (
@@ -60,4 +60,4 @@ export const AppHeader = () => {
       </nav>
     </header>
   );
-};
+}

--- a/src/components/AppLink.tsx
+++ b/src/components/AppLink.tsx
@@ -6,7 +6,7 @@ import { cn } from "../lib/util";
 type Props = Omit<ComponentProps<typeof NextLink>, "href"> &
   Pick<ComponentProps<"a">, "href">;
 
-export const AppLink = (props: Props) => {
+export function AppLink(props: Props) {
   const { href, children, className, ...rest } = props;
 
   const linkClassName = cn(
@@ -32,4 +32,4 @@ export const AppLink = (props: Props) => {
       </Link>
     );
   }
-};
+}

--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -36,7 +36,7 @@ function childToString(child?: ReactNode): string {
   return child.toString();
 }
 
-export const CodeBlock = (props: React.ComponentProps<"pre">) => {
+export function CodeBlock(props: React.ComponentProps<"pre">) {
   const text = extractText(props.children);
   return (
     <div className="relative">
@@ -46,4 +46,4 @@ export const CodeBlock = (props: React.ComponentProps<"pre">) => {
       </pre>
     </div>
   );
-};
+}

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useState } from "react";
 import { Copy, Check } from "react-feather";
 
-export const CopyButton = ({ text }: { text: string }) => {
+export function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false);
 
   const handleClick = useCallback(async () => {
@@ -22,4 +22,4 @@ export const CopyButton = ({ text }: { text: string }) => {
       {copied ? <Check size={16} /> : <Copy size={16} />}
     </button>
   );
-};
+}

--- a/src/components/EntryImage.tsx
+++ b/src/components/EntryImage.tsx
@@ -8,7 +8,7 @@ interface Props extends ImageProps {
   slug: string;
 }
 
-export const EntryImage = async ({ src, alt, slug, ...rest }: Props) => {
+export async function EntryImage({ src, alt, slug, ...rest }: Props) {
   if (typeof src !== "string")
     throw new Error("EntyImage does not support StaticImport.");
 
@@ -25,4 +25,4 @@ export const EntryImage = async ({ src, alt, slug, ...rest }: Props) => {
       {...rest}
     />
   );
-};
+}

--- a/src/components/EntryList.tsx
+++ b/src/components/EntryList.tsx
@@ -5,7 +5,7 @@ import { AppLink } from "./AppLink";
 interface Props {
   entries: Omit<Entry, "body">[];
 }
-export const EntryList = (props: Props) => {
+export function EntryList(props: Props) {
   return (
     <ul>
       {props.entries.map((entry) => (
@@ -36,4 +36,4 @@ export const EntryList = (props: Props) => {
       ))}
     </ul>
   );
-};
+}

--- a/src/components/EntryView.tsx
+++ b/src/components/EntryView.tsx
@@ -36,7 +36,7 @@ const levelMarker = {
   6: "before:content-['######_']",
 };
 
-const Heading = ({ level, children, id, ...rest }: HeadingProps) => {
+function Heading({ level, children, id, ...rest }: HeadingProps) {
   return createElement(
     `h${level}`,
     {
@@ -60,16 +60,16 @@ const Heading = ({ level, children, id, ...rest }: HeadingProps) => {
       </a>,
     ],
   );
-};
+}
 
-const Img = ({
+function Img({
   src,
   alt,
   width,
   height,
   slug,
   ...rest
-}: ImgHTMLAttributes<HTMLImageElement> & { slug: string }) => {
+}: ImgHTMLAttributes<HTMLImageElement> & { slug: string }) {
   if (!width || !height) throw new Error("Cannot get width or height");
   if (typeof src !== "string") throw new Error("Don't use srcObject");
   const nonNullableSrc = src || "";
@@ -91,9 +91,9 @@ const Img = ({
       </ZoomWrapper>
     </div>
   );
-};
+}
 
-export const EntryView = async ({ entry, shareButton, path }: Props) => {
+export async function EntryView({ entry, shareButton, path }: Props) {
   const url = buildFullPath(path);
   const entryTitleWithBlogName = config.title(entry.title);
   return (
@@ -174,4 +174,4 @@ export const EntryView = async ({ entry, shareButton, path }: Props) => {
       )}
     </article>
   );
-};
+}

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,6 +1,6 @@
 import { type SVGProps } from "react";
 
-export const Logo = (props: SVGProps<SVGSVGElement>) => {
+export function Logo(props: SVGProps<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -40,4 +40,4 @@ export const Logo = (props: SVGProps<SVGSVGElement>) => {
       />
     </svg>
   );
-};
+}

--- a/src/components/ShareButtons.tsx
+++ b/src/components/ShareButtons.tsx
@@ -13,7 +13,7 @@ interface Props {
   url: string;
 }
 
-export const ShareButtons = ({ url, text }: Props) => {
+export function ShareButtons({ url, text }: Props) {
   const openDialog: MouseEventHandler<HTMLAnchorElement> = useCallback(
     (e) => {
       window.open(
@@ -93,4 +93,4 @@ export const ShareButtons = ({ url, text }: Props) => {
       )}
     </>
   );
-};
+}

--- a/src/components/ZoomWrapper.tsx
+++ b/src/components/ZoomWrapper.tsx
@@ -4,6 +4,6 @@ import { PropsWithChildren } from "react";
 import Zoom from "react-medium-image-zoom";
 import "react-medium-image-zoom/dist/styles.css";
 
-export const ZoomWrapper = ({ children }: PropsWithChildren) => {
+export function ZoomWrapper({ children }: PropsWithChildren) {
   return <Zoom>{children}</Zoom>;
-};
+}

--- a/src/lib/dateUtil.ts
+++ b/src/lib/dateUtil.ts
@@ -6,7 +6,7 @@ dayjs.extend(timezone);
 dayjs.extend(utc);
 dayjs.tz.setDefault("Asia/Tokyo");
 
-export const yyyymmdd = (date: number) => {
+export function yyyymmdd(date: number) {
   const day = dayjs.utc(date).local();
   return [day.format("YYYY.MM.DD"), day] as const;
-};
+}

--- a/src/lib/entry.ts
+++ b/src/lib/entry.ts
@@ -12,10 +12,11 @@ export interface Entry {
   date: number;
 }
 
-const getEntryPath = (slug: string) =>
-  path.join(blogDir, slug, "/", "index.md");
+function getEntryPath(slug: string) {
+  return path.join(blogDir, slug, "/", "index.md");
+}
 
-export const getEntry = async (slug: string): Promise<Entry> => {
+export async function getEntry(slug: string): Promise<Entry> {
   const mdPath = getEntryPath(slug);
   const md = await fs.readFile(mdPath, "utf-8");
   const { data, content } = matter(md);
@@ -26,13 +27,13 @@ export const getEntry = async (slug: string): Promise<Entry> => {
     date: new Date(data.date).getTime(),
     slug,
   };
-};
+}
 
-export const getEntries = async (limit?: number): Promise<Entry[]> => {
+export async function getEntries(limit?: number): Promise<Entry[]> {
   const dirents = await fs.readdir(blogDir, { withFileTypes: true });
   const slugs = dirents
     .filter((dirent) => dirent.isDirectory())
     .map((dirent) => dirent.name);
   const entries = await Promise.all(slugs.map(getEntry));
   return entries.toSorted((a, b) => b.date - a.date).slice(0, limit);
-};
+}

--- a/src/lib/ogUtil.tsx
+++ b/src/lib/ogUtil.tsx
@@ -18,10 +18,10 @@ const googleFontsApiKey = process.env.GOOGLE_FONTS_API_KEY!;
 const endpoint = new URL("https://www.googleapis.com/webfonts/v1/webfonts");
 endpoint.searchParams.set("key", googleFontsApiKey);
 
-const fetchFontArrayBuffer = async (
+async function fetchFontArrayBuffer(
   fontFamily: string,
   weight: string | number = "regular",
-) => {
+) {
   endpoint.searchParams.set("family", fontFamily);
 
   // cf. https://developers.google.com/fonts/docs/developer_api#a_quick_example
@@ -29,11 +29,11 @@ const fetchFontArrayBuffer = async (
   const fontResponse = await fetch(fontInfo.items[0].files[weight]);
   const fontBuffer = await fontResponse.arrayBuffer();
   return fontBuffer;
-};
+}
 
-export const imageResponseWithFont = async (
+export async function imageResponseWithFont(
   element: ReactElement<unknown, string | JSXElementConstructor<unknown>>,
-) => {
+) {
   const [notoSansJp, inter] = await Promise.all([
     fetchFontArrayBuffer("Noto Sans JP"),
     fetchFontArrayBuffer("Inter"),
@@ -55,7 +55,7 @@ export const imageResponseWithFont = async (
       },
     ],
   });
-};
+}
 
 export const coloredTitle = config
   .title()
@@ -71,11 +71,11 @@ export const coloredTitle = config
     </span>
   ));
 
-export const OgBackground = ({
+export function OgBackground({
   tw,
   style,
   ...props
-}: PropsWithChildren<React.HTMLAttributes<HTMLDivElement>>) => {
+}: PropsWithChildren<React.HTMLAttributes<HTMLDivElement>>) {
   return (
     <div
       style={{
@@ -97,12 +97,12 @@ export const OgBackground = ({
       {props.children}
     </div>
   );
-};
+}
 
-export const imageResponseWithFontChildPage = async (
+export async function imageResponseWithFontChildPage(
   title: string,
   date?: string,
-) => {
+) {
   return imageResponseWithFont(
     <OgBackground>
       {date && <div tw="flex text-4xl opacity-75">{date}</div>}
@@ -110,7 +110,7 @@ export const imageResponseWithFontChildPage = async (
       <div tw="flex text-5xl mt-10">{coloredTitle}</div>
     </OgBackground>,
   );
-};
+}
 
 export const commonOpenGraph: OpenGraph = {
   siteName: config.title(),

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -2,6 +2,10 @@ import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 import { config } from "../../blog.config";
 
-export const buildFullPath = (path: string) => `${config.baseUrl}${path}`;
+export function buildFullPath(path: string) {
+  return `${config.baseUrl}${path}`;
+}
 
-export const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## Summary
- Convert all arrow function expressions (`const fn = () => {}`) to function declarations (`function fn() {}`) across 18 source files
- Preserves arrow functions inside hooks (`useCallback`) and object literal properties as they are idiomatic patterns

## Test plan
- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] Verify build succeeds
- [x] Verify no runtime regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)