### PR TITLE
chore(deps): bump pnpm from 11.13.0 to 11.24.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,5 +61,5 @@
     "prettier-plugin-tailwindcss": "0.8.0",
     "typescript": "6.0.3"
   },
-  "packageManager": "pnpm@11.13.0"
+  "packageManager": "pnpm@11.24.0"
 }


### PR DESCRIPTION
## Summary
- pnpm 11.13.0 was marked as a broken release (`ERR_PNPM_BROKEN_PNPM_RELEASE`: the `@pnpm/exe` build shipped without a binary), so `pnpm/action-setup` refuses to install it and CI fails before `pnpm install` runs (see #1735's failing build job).
- Bump `packageManager` to pnpm 11.24.0 (current latest). Verified locally that `pnpm install --frozen-lockfile` succeeds with 11.24.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019tbKHCShtQMe1H7VN5yvSc